### PR TITLE
Bind to instance of ResultModule

### DIFF
--- a/algebra-jackson/src/main/java/com/hubspot/algebra/AlgebraJacksonModule.java
+++ b/algebra-jackson/src/main/java/com/hubspot/algebra/AlgebraJacksonModule.java
@@ -9,7 +9,7 @@ public class AlgebraJacksonModule extends AbstractModule {
   protected void configure() {
     Multibinder.newSetBinder(binder(), Module.class)
         .addBinding()
-        .to(ResultModule.class);
+        .toInstance(new ResultModule());
   }
 
 

--- a/algebra-jackson/src/main/java/com/hubspot/algebra/ResultModule.java
+++ b/algebra-jackson/src/main/java/com/hubspot/algebra/ResultModule.java
@@ -2,7 +2,6 @@ package com.hubspot.algebra;
 
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.Module;
-import com.google.inject.Inject;
 
 public class ResultModule extends Module {
   static final String CASE_FIELD_NAME = "@result";
@@ -12,9 +11,6 @@ public class ResultModule extends Module {
     OK,
     ERR;
   }
-
-  @Inject
-  public ResultModule() {}
 
   @Override
   public String getModuleName() {

--- a/algebra-jackson/src/main/java/com/hubspot/algebra/ResultModule.java
+++ b/algebra-jackson/src/main/java/com/hubspot/algebra/ResultModule.java
@@ -2,6 +2,7 @@ package com.hubspot.algebra;
 
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.Module;
+import com.google.inject.Inject;
 
 public class ResultModule extends Module {
   static final String CASE_FIELD_NAME = "@result";
@@ -11,6 +12,9 @@ public class ResultModule extends Module {
     OK,
     ERR;
   }
+
+  @Inject
+  public ResultModule() {}
 
   @Override
   public String getModuleName() {


### PR DESCRIPTION
This this is bound in a multibinder in `AlgebraJacksonModule` which currently breaks if `requireAtInjectOnConstructors` is set on the guice binder.

@szabowexler @jhaber 