### PR TITLE
Add void result

### DIFF
--- a/algebra/src/main/java/com/hubspot/algebra/VoidResult.java
+++ b/algebra/src/main/java/com/hubspot/algebra/VoidResult.java
@@ -1,0 +1,52 @@
+package com.hubspot.algebra;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.derive4j.Data;
+import org.derive4j.Derive;
+import org.derive4j.Visibility;
+
+@Data(@Derive(withVisibility = Visibility.Package))
+public abstract class VoidResult<ERROR_TYPE> extends Result<Void, ERROR_TYPE>{
+
+  public static <E> VoidResult<E> ok() {
+    return VoidResults.ok(null);
+  }
+
+  public static <ERROR_TYPE> VoidResult<ERROR_TYPE> error(ERROR_TYPE error) {
+    return VoidResults.err(error);
+  }
+
+  VoidResult() { }
+
+  @Override
+  public boolean isOk() {
+    return !super.isErr();
+  }
+
+  @Override
+  public void ifOk(Consumer<? super Void> consumer) {
+    consumer.accept(null);
+  }
+
+  @Override
+  public <NEW_SUCCESS_TYPE> Result<NEW_SUCCESS_TYPE, ERROR_TYPE> mapOk(Function<Void, NEW_SUCCESS_TYPE> mapper) {
+    return this.match(Results::err,
+        (ok) -> Results.ok(mapper.apply(null)));
+  }
+
+  @Override
+  public <NEW_SUCCESS_TYPE> Result<NEW_SUCCESS_TYPE, ERROR_TYPE> flatMapOk(Function<Void, Result<NEW_SUCCESS_TYPE, ERROR_TYPE>> mapper) {
+    Result<Result<NEW_SUCCESS_TYPE, ERROR_TYPE>, ERROR_TYPE> nestedResult = this.mapOk(mapper);
+
+    if (nestedResult.isErr()) {
+      return err(nestedResult.unwrapErrOrElseThrow());
+    }
+
+    return nestedResult.unwrapOrElseThrow();
+  }
+
+  public abstract <R> R match(Function<ERROR_TYPE, R> err, Function<Void, R> ok);
+
+}

--- a/algebra/src/test/java/com/hubspot/algebra/VoidResultTest.java
+++ b/algebra/src/test/java/com/hubspot/algebra/VoidResultTest.java
@@ -1,0 +1,24 @@
+package com.hubspot.algebra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class VoidResultTest {
+
+  private static final VoidResult<String> OK_RESULT = VoidResult.ok();
+  private static final VoidResult<String> ERR_RESULT = VoidResult.error("ERROR");
+
+  @Test
+  public void itHandlesOk() throws Exception {
+    assertThat(OK_RESULT.isOk()).isTrue();
+    assertThat(OK_RESULT.isErr()).isFalse();
+  }
+
+
+  @Test
+  public void itHandlesErr() throws Exception {
+    assertThat(ERR_RESULT.isOk()).isFalse();
+    assertThat(ERR_RESULT.isErr()).isTrue();
+  }
+}


### PR DESCRIPTION
This adds a new special case `VoidResult` to handle issues with using the standard `Result<Void, E>` (namely that things like `isOk` will throw an NPE).

@szabowexler @axiak 