### PR TITLE
Enable (de)serialization for non-bean types

### DIFF
--- a/algebra-jackson/src/main/java/com/hubspot/algebra/ResultDeserializer.java
+++ b/algebra-jackson/src/main/java/com/hubspot/algebra/ResultDeserializer.java
@@ -2,6 +2,7 @@ package com.hubspot.algebra;
 
 import static com.hubspot.algebra.ResultModule.CASE_FIELD_NAME;
 import static com.hubspot.algebra.ResultModule.ERROR_FIELD_NAME;
+import static com.hubspot.algebra.ResultModule.OK_FIELD_NAME;
 
 import java.io.IOException;
 
@@ -42,16 +43,21 @@ public class ResultDeserializer extends StdDeserializer<Result<?, ?>> {
     node.remove(CASE_FIELD_NAME);
 
     if (resultCase.equalsIgnoreCase(Case.ERR.toString())) {
-      if (node.has(ERROR_FIELD_NAME)) {
-        Object err = objectMapper.treeToValue(node.findValue(ERROR_FIELD_NAME), errClass);
-        return Results.err(err);
-      }
-
-      Object err = objectMapper.treeToValue(node, errClass);
+      Object err = deserializeValue(objectMapper, node, ERROR_FIELD_NAME, errClass);
       return Results.err(err);
     } else {
-      Object ok = objectMapper.treeToValue(node, okClass);
+      Object ok = deserializeValue(objectMapper, node, OK_FIELD_NAME, okClass);
       return Results.ok(ok);
     }
+  }
+
+  private static Object deserializeValue(
+      ObjectMapper objectMapper,
+      ObjectNode node,
+      String fieldName,
+      Class<?> clazz
+  ) throws JsonProcessingException {
+    JsonNode valueNode = node.has(fieldName) ? node.findValue(fieldName) : node;
+    return objectMapper.treeToValue(valueNode, clazz);
   }
 }

--- a/algebra-jackson/src/main/java/com/hubspot/algebra/ResultModule.java
+++ b/algebra-jackson/src/main/java/com/hubspot/algebra/ResultModule.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.Module;
 
 public class ResultModule extends Module {
   static final String CASE_FIELD_NAME = "@result";
+  static final String OK_FIELD_NAME = "@ok";
   static final String ERROR_FIELD_NAME = "@error";
 
   enum Case {

--- a/algebra-jackson/src/main/java/com/hubspot/algebra/ResultSerializer.java
+++ b/algebra-jackson/src/main/java/com/hubspot/algebra/ResultSerializer.java
@@ -2,6 +2,7 @@ package com.hubspot.algebra;
 
 import static com.hubspot.algebra.ResultModule.CASE_FIELD_NAME;
 import static com.hubspot.algebra.ResultModule.ERROR_FIELD_NAME;
+import static com.hubspot.algebra.ResultModule.OK_FIELD_NAME;
 
 import java.io.IOException;
 
@@ -9,7 +10,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.EnumSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.hubspot.algebra.ResultModule.Case;
 
@@ -24,28 +24,28 @@ public class ResultSerializer extends StdSerializer<Result<?, ?>> {
 
     if (value.isErr()) {
       Object err = value.unwrapErrOrElseThrow();
-      JsonSerializer<?> errorSerializer = provider.findTypedValueSerializer(err.getClass(), true, null);
-
-      if (errorSerializer instanceof EnumSerializer) {
-        EnumSerializer enumSerializer = ((EnumSerializer) errorSerializer);
-        Enum<?> enumErr = ((Enum<?>) err);
-
-        gen.writeFieldName(ERROR_FIELD_NAME);
-        enumSerializer.serialize(enumErr, gen, provider);
-      } else {
-        JsonSerializer<Object> objectErrorSerializer = ((JsonSerializer<Object>) errorSerializer);
-        objectErrorSerializer.unwrappingSerializer(null).serialize(err, gen, provider);
-      }
-
+      serializeValue(ERROR_FIELD_NAME, err, gen, provider);
       gen.writeStringField(CASE_FIELD_NAME, Case.ERR.name());
     } else {
       Object ok = value.unwrapOrElseThrow();
-
-      JsonSerializer<Object> okSerializer = provider.findTypedValueSerializer(ok.getClass(), true, null);
-      okSerializer.unwrappingSerializer(null).serialize(ok, gen, provider);
+      serializeValue(OK_FIELD_NAME, ok, gen, provider);
       gen.writeStringField(CASE_FIELD_NAME, Case.OK.name());
     }
 
     gen.writeEndObject();
+  }
+
+  private static void serializeValue(
+      String fieldName,
+      Object value,
+      JsonGenerator gen,
+      SerializerProvider provider
+  ) throws IOException {
+    JsonSerializer<Object> serializer = provider.findTypedValueSerializer(value.getClass(), true, null)
+                                                .unwrappingSerializer(null);
+    if (!serializer.isUnwrappingSerializer()) {
+      gen.writeFieldName(fieldName);
+    }
+    serializer.serialize(value, gen, provider);
   }
 }

--- a/algebra-jackson/src/test/java/com/hubspot/algebra/ResultModuleTest.java
+++ b/algebra-jackson/src/test/java/com/hubspot/algebra/ResultModuleTest.java
@@ -2,6 +2,9 @@ package com.hubspot.algebra;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -24,6 +27,10 @@ public class ResultModuleTest {
   private static final String EXPECTED_OK = "{\"value\":\"test\",\"@result\":\"OK\"}";
   private static final String EXPECTED_ERR = "{\"name\":\"ERROR\",\"@result\":\"ERR\"}";
   private static final String EXPECTED_RAW_ERR = "{\"@error\":\"ERROR\",\"@result\":\"ERR\"}";
+  private static final String EXPECTED_STRING_OK = "{\"@ok\":\"test\",\"@result\":\"OK\"}";
+  private static final String EXPECTED_STRING_ERR = "{\"@error\":\"ERROR\",\"@result\":\"ERR\"}";
+  private static final String EXPECTED_LIST_OK = "{\"@ok\":[\"val0\",\"val1\"],\"@result\":\"OK\"}";
+  private static final String EXPECTED_LIST_ERR = "{\"@error\":[\"err0\",\"err1\"],\"@result\":\"ERR\"}";
 
   @Test
   public void itSerializesOk() throws Exception {
@@ -44,6 +51,30 @@ public class ResultModuleTest {
     Result<TestBean, RawError> result = Result.err(RawError.ERROR);
 
     assertThat(objectMapper.writeValueAsString(result)).isEqualTo(EXPECTED_RAW_ERR);
+  }
+
+  @Test
+  public void itSerializesStringOk() throws Exception {
+    Result<String, String> result = Result.ok("test");
+    assertThat(objectMapper.writeValueAsString(result)).isEqualTo(EXPECTED_STRING_OK);
+  }
+
+  @Test
+  public void itSerializesStringErr() throws Exception {
+    Result<String, String> result = Result.err("ERROR");
+    assertThat(objectMapper.writeValueAsString(result)).isEqualTo(EXPECTED_STRING_ERR);
+  }
+
+  @Test
+  public void itSerializesListOk() throws Exception {
+    Result<List<String>, List<String>> result = Result.ok(Arrays.asList("val0", "val1"));
+    assertThat(objectMapper.writeValueAsString(result)).isEqualTo(EXPECTED_LIST_OK);
+  }
+
+  @Test
+  public void itSerializesListErr() throws Exception {
+    Result<List<String>, List<String>> result = Result.err(Arrays.asList("err0", "err1"));
+    assertThat(objectMapper.writeValueAsString(result)).isEqualTo(EXPECTED_LIST_ERR);
   }
 
   @Test
@@ -68,6 +99,30 @@ public class ResultModuleTest {
 
     assertThat(result.isErr()).isTrue();
     assertThat(result.unwrapErrOrElseThrow()).isEqualTo(RawError.ERROR);
+  }
+
+  @Test
+  public void itDeserializesStringOk() throws Exception {
+    Result<String, String> actual = objectMapper.readValue(EXPECTED_STRING_OK, new TypeReference<Result<String, String>>(){});
+    assertThat(actual).isEqualTo(Result.ok("test"));
+  }
+
+  @Test
+  public void itDeserializesStringErr() throws Exception {
+    Result<String, String> actual = objectMapper.readValue(EXPECTED_STRING_ERR, new TypeReference<Result<String, String>>(){});
+    assertThat(actual).isEqualTo(Result.err("ERROR"));
+  }
+
+  @Test
+  public void itDeserializesListOk() throws Exception {
+    Result<List<String>, List<String>> actual = objectMapper.readValue(EXPECTED_LIST_OK, new TypeReference<Result<List<String>, List<String>>>(){});
+    assertThat(actual).isEqualTo(Result.ok(Arrays.asList("val0", "val1")));
+  }
+
+  @Test
+  public void itDeserializesListErr() throws Exception {
+    Result<List<String>, List<String>> actual = objectMapper.readValue(EXPECTED_LIST_ERR, new TypeReference<Result<List<String>, List<String>>>(){});
+    assertThat(actual).isEqualTo(Result.err(Arrays.asList("err0", "err1")));
   }
 
   static class TestBean {


### PR DESCRIPTION
This makes it so that non-bean values can be (de)serialized under the `@ok` field.

@szabowexler @jhaber @zklapow @kmclarnon 