### PR TITLE
Call the parent algebra-parent (no 'public')

### DIFF
--- a/algebra-jackson/pom.xml
+++ b/algebra-jackson/pom.xml
@@ -4,12 +4,11 @@
 
   <parent>
     <groupId>com.hubspot</groupId>
-    <artifactId>algebra-public-parent</artifactId>
+    <artifactId>algebra-parent</artifactId>
     <version>1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>algebra-jackson</artifactId>
-  <version>1.3-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/algebra-testing/pom.xml
+++ b/algebra-testing/pom.xml
@@ -4,12 +4,11 @@
 
   <parent>
     <groupId>com.hubspot</groupId>
-    <artifactId>algebra-public-parent</artifactId>
+    <artifactId>algebra-parent</artifactId>
     <version>1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>algebra-testing</artifactId>
-  <version>1.3-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/algebra/pom.xml
+++ b/algebra/pom.xml
@@ -4,12 +4,11 @@
 
   <parent>
     <groupId>com.hubspot</groupId>
-    <artifactId>algebra-public-parent</artifactId>
+    <artifactId>algebra-parent</artifactId>
     <version>1.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>algebra</artifactId>
-  <version>1.3-SNAPSHOT</version>
 
   <properties>
     <basepom.check.skip-findbugs>true</basepom.check.skip-findbugs>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>18.2</version>
   </parent>
 
-  <artifactId>algebra-public-parent</artifactId>
+  <artifactId>algebra-parent</artifactId>
   <version>1.3-SNAPSHOT</version>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
The `public` thing here is pretty annoying. I plan on renaming the repo after this is merged.

@szabowexler @jhaber @kmclarnon